### PR TITLE
Test cases for turbulence modeling

### DIFF
--- a/turbulence_models/sa/rae2822/mesh_RAE2822_turb.su2
+++ b/turbulence_models/sa/rae2822/mesh_RAE2822_turb.su2
@@ -1,0 +1,1 @@
+../../../rans/rae2822/mesh_RAE2822_turb.su2


### PR DESCRIPTION
This pull request accompanies the [Feature turbmod variants](https://github.com/su2code/SU2/pull/1413) pull request. Here I create a test cases directory for regression testing of the turbulence models and their variants. For the moment I have only implemented it for the SA model.

In the future the turbulence_models directory should include the test cases files for the other turbulence models and their variants, e.g. SST.

The selected configuration is the rae2822 airfoil from the rans directory. Hence, I just created a symbolic link to that mesh.