### PR TITLE
Change NDIME in mesh to correct 3 instead of 2.

### DIFF
--- a/incomp_navierstokes/streamwise_periodic/chtPinArray_3d/3D_chtPinArray_coarse.su2
+++ b/incomp_navierstokes/streamwise_periodic/chtPinArray_3d/3D_chtPinArray_coarse.su2
@@ -1,4 +1,4 @@
-NDIME= 2
+NDIME= 3
 NZONE= 2
 
 IZONE= 1


### PR DESCRIPTION
NDIME=3 instead of NDIME=2 ...

Noticed when I wanted to update a reg test to use `INTEGRATED_HEATFLUX` over at https://github.com/su2code/SU2/pull/1530